### PR TITLE
Support Kernel 6.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,12 @@ else
 	always-y := $(dtbo-y)
 endif
 
+ifeq ($(wildcard /boot/firmware/config.txt),)
+    BOOT_CONFIG := /boot/config.txt
+else
+    BOOT_CONFIG := /boot/firmware/config.txt
+endif
+
 all:
 	make -C /lib/modules/$(KERNELRELEASE)/build M=$(PWD) modules
 
@@ -33,6 +39,6 @@ install: tagtagtag-ears.ko tagtagtag-ears.dtbo
 	depmod -a $(KERNELRELEASE)
 	install -o root -m 644 tagtagtag-ears.dtbo /boot/overlays/
 	sed /boot/config.txt -i -e "s/^#dtoverlay=tagtagtag-ears/dtoverlay=tagtagtag-ears/"
-	grep -q -E "^dtoverlay=tagtagtag-ears" /boot/config.txt || printf "dtoverlay=tagtagtag-ears\n" >> /boot/config.txt
+	grep -q -E "^dtoverlay=tagtagtag-ears" $(BOOT_CONFIG) || printf "dtoverlay=tagtagtag-ears\n" >> $(BOOT_CONFIG)
 
 .PHONY: all clean install

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,14 @@ endif
 all:
 	make -C /lib/modules/$(KERNELRELEASE)/build M=$(PWD) modules
 
+# dtbo rule is no longer available
+ifeq ($(firstword $(subst ., ,$(KERNELRELEASE))),6)
+all: tagtagtag-ears.dtbo
+
+tagtagtag-ears.dtbo: tagtagtag-ears-overlay.dts
+	dtc -I dts -O dtb -o $@ $<
+endif
+
 clean:
 	make -C /lib/modules/$(KERNELRELEASE)/build M=$(PWD) clean
 

--- a/README.md
+++ b/README.md
@@ -5,16 +5,28 @@ Creates `/dev/ear0` (left) and `/dev/ear1` (right) to drive tagtagtag ears.
 
 ## Installation
 
+Install requirements
+
+    sudo apt-get install raspberrypi-kernel-headers
+
+Clone source code.
+
+    git clone https://github.com/pguyot/tagtagtag-ears
+
+Compile and install with
+
+    cd tagtagtag-ears
     make
     sudo make install
 
-This adds:
+Makefile will automatically edit /boot/config.txt and add/enable if required
+the following params and overlays:
 
     dtoverlay=tagtagtag-ears
 
-to /boot/config.txt
+You might want to review changes before rebooting.
 
-    reboot
+Reboot.
 
 ## Usage
 

--- a/tagtagtag-ears.c
+++ b/tagtagtag-ears.c
@@ -39,6 +39,7 @@
 #include <linux/wait.h>
 #include <linux/uaccess.h>
 #include <linux/poll.h>
+#include <linux/version.h>
 
 // Definitions
 
@@ -885,7 +886,12 @@ static int tagtagtagears_probe(struct platform_device *pdev) {
     }
 
 	// Create device class
-	priv->ears_class = class_create(THIS_MODULE, DEVICE_NAME);
+    #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
+        priv->ears_class = class_create(THIS_MODULE, DEVICE_NAME);
+    #else
+            priv->ears_class = class_create(DEVICE_NAME);
+    #endif
+
 	if (IS_ERR(priv->ears_class)) {
 		err = PTR_ERR(priv->ears_class);
         dev_err(dev, "class_create failed: %d", err);


### PR DESCRIPTION
Port the same changes applied to the `cr14` and `wm8960` drivers.

This PR fixes build errors on `6.6.28+rpt-rpi-v6` (latest as the time of writing).
Seeing the other PRs, I think it fixes compilation on all 6.x kernels:

- https://github.com/pguyot/cr14/pull/17
- https://github.com/pguyot/wm8960/commit/b552bdcedb74d162daf2318fc77116b2f209a84e

I've also updated the README Installation section to be in pair with the other repos.

Note: `cr14` Makefile needs to be updated as well to reflect the changes related to the variable /boot/config.txt location.